### PR TITLE
[LEARN-4396] Criando e testando endpoint DELETE /user/me

### DIFF
--- a/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
@@ -38,13 +38,17 @@ defmodule ApiBlogsWeb.UserController do
   #   end
   # end
 
-  # def delete(conn, %{"id" => id}) do
-  #   user = Blog.get_user!(id)
+  def delete(conn, _params) do
+    jwt = conn.private[:guardian_default_token]
+    {:ok, claims} = Guardian.decode_and_verify(jwt)
+    id = claims["sub"]
 
-  #   with {:ok, %User{}} <- Blog.delete_user(user) do
-  #     send_resp(conn, :no_content, "")
-  #   end
-  # end
+    user = Blog.get_user!(id)
+
+    with {:ok, %User{}} <- Blog.delete_user(user) do
+      send_resp(conn, :no_content, "")
+    end
+  end
 
   def login(conn, %{"user" => user_params}) do
     with {:ok, %{} = user} <- Blog.do_login(user_params),

--- a/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
@@ -39,15 +39,16 @@ defmodule ApiBlogsWeb.UserController do
   # end
 
   def delete(conn, _params) do
-    jwt = conn.private[:guardian_default_token]
-    {:ok, claims} = Guardian.decode_and_verify(jwt)
-    id = claims["sub"]
+    with {:ok, %{"sub" => id}} <- extract_id(conn),
+      user <- Blog.get_user!(id),
+      {:ok, %User{}} <- Blog.delete_user(user) do
+        send_resp(conn, :no_content, "")
+      end
+  end
 
-    user = Blog.get_user!(id)
-
-    with {:ok, %User{}} <- Blog.delete_user(user) do
-      send_resp(conn, :no_content, "")
-    end
+  defp extract_id(conn) do
+    conn.private[:guardian_default_token]
+    |> Guardian.decode_and_verify()
   end
 
   def login(conn, %{"user" => user_params}) do

--- a/api_blogs/lib/api_blogs_web/router.ex
+++ b/api_blogs/lib/api_blogs_web/router.ex
@@ -42,6 +42,7 @@ defmodule ApiBlogsWeb.Router do
 
     get "/user", UserController, :index
     get "/user/:id", UserController, :show
+    delete "/user/me", UserController, :delete
   end
 
   # Enables LiveDashboard only for development

--- a/api_blogs/test/api_blogs_web/controllers/user_controller_test.exs
+++ b/api_blogs/test/api_blogs_web/controllers/user_controller_test.exs
@@ -38,8 +38,8 @@ defmodule ApiBlogsWeb.UserControllerTest do
       split_response_body = String.split(conn.resp_body, "\"")
       [_ | [_ | [_ | [jwt | _]]]] = split_response_body
 
-      conn = build_conn()
-      conn = conn
+      conn =
+      build_conn()
       |> put_req_header("authorization", "bearer " <> jwt)
       |> get(Routes.user_path(conn, :index))
 
@@ -71,8 +71,8 @@ defmodule ApiBlogsWeb.UserControllerTest do
       split_response_body = String.split(conn.resp_body, "\"")
       [_ | [_ | [_ | [jwt | _]]]] = split_response_body
 
-      conn = build_conn()
-      conn = conn
+      conn =
+      build_conn()
       |> put_req_header("authorization", "bearer " <> jwt)
       |> get(Routes.user_path(conn, :index))
 
@@ -168,8 +168,8 @@ defmodule ApiBlogsWeb.UserControllerTest do
     setup [:add_user]
 
     test "returns correct user info", %{conn: conn, jwt: jwt} do
-      conn = build_conn()
-      conn = conn
+      conn =
+      build_conn()
       |> put_req_header("authorization", "bearer " <> jwt)
       |> get(Routes.user_path(conn, :index))
 
@@ -182,8 +182,8 @@ defmodule ApiBlogsWeb.UserControllerTest do
     end
 
     test "returns error for nonexistent user", %{conn: conn, jwt: jwt} do
-      conn = build_conn()
-      conn = conn
+      conn =
+      build_conn()
       |> put_req_header("authorization", "bearer " <> jwt)
       |> get(Routes.user_path(conn, :index))
 
@@ -195,9 +195,8 @@ defmodule ApiBlogsWeb.UserControllerTest do
     end
 
     test "returns error for invalid jwt", %{conn: conn} do
-      conn = build_conn()
       conn =
-      conn
+      build_conn()
       |> put_req_header("authorization", "bearer abcd")
       |> get(Routes.user_path(conn, :show, 1))
 
@@ -238,8 +237,8 @@ defmodule ApiBlogsWeb.UserControllerTest do
     setup [:add_user]
 
     test "successfull delete", %{conn: conn, jwt: jwt} do
-      conn = build_conn()
-      conn = conn
+      conn =
+      build_conn()
       |> put_req_header("authorization", "bearer " <> jwt)
       |> delete(Routes.user_path(conn, :delete))
 
@@ -247,9 +246,8 @@ defmodule ApiBlogsWeb.UserControllerTest do
     end
 
     test "returns error for invalid jwt", %{conn: conn} do
-      conn = build_conn()
       conn =
-      conn
+      build_conn()
       |> put_req_header("authorization", "bearer abcd")
       |> delete(Routes.user_path(conn, :delete))
 

--- a/api_blogs/test/api_blogs_web/controllers/user_controller_test.exs
+++ b/api_blogs/test/api_blogs_web/controllers/user_controller_test.exs
@@ -234,18 +234,33 @@ defmodule ApiBlogsWeb.UserControllerTest do
   #   end
   # end
 
-  # describe "delete user" do
-  #   setup [:create_user]
+  describe "delete user" do
+    setup [:add_user]
 
-  #   test "deletes chosen user", %{conn: conn, user: user} do
-  #     conn = delete(conn, Routes.user_path(conn, :delete, user))
-  #     assert response(conn, 204)
+    test "successfull delete", %{conn: conn, jwt: jwt} do
+      conn = build_conn()
+      conn = conn
+      |> put_req_header("authorization", "bearer " <> jwt)
+      |> delete(Routes.user_path(conn, :delete))
 
-  #     assert_error_sent 404, fn ->
-  #       get(conn, Routes.user_path(conn, :show, user))
-  #     end
-  #   end
-  # end
+      assert response(conn, 204) == ""
+    end
+
+    test "returns error for invalid jwt", %{conn: conn} do
+      conn = build_conn()
+      conn =
+      conn
+      |> put_req_header("authorization", "bearer abcd")
+      |> delete(Routes.user_path(conn, :delete))
+
+      assert json_response(conn, 401) == %{"message" => "Token expirado ou invalido"}
+    end
+
+    test "returns error for missing jwt", %{conn: conn} do
+      conn = delete(conn, Routes.user_path(conn, :delete))
+      assert json_response(conn, 401) == %{"message" => "Token nao encontrado"}
+    end
+  end
 
   describe "user login" do
     setup [:add_user]

--- a/api_blogs/test_branch.md
+++ b/api_blogs/test_branch.md
@@ -1,1 +1,0 @@
-Teste da branch


### PR DESCRIPTION
[Tarefa no Jira](https://trybe.atlassian.net/jira/software/c/projects/LEARN/boards/56?modal=detail&selectedIssue=LEARN-4396&assignee=61eed0dd25edab006afb4305)

A API de blogs deve ter um endpoint capaz de deletar um usuário dado seu token JWT de autenticação. 

Foi criada uma nova rota no router, e a função original de deletar um usuário, gerada pelo comando 

`mix phx.gen.json Blog User users displayName:string email:string:unique password:string image:string`

foi modificada para incluir a decodificação do token JWT. Além disso, foram criados testes para garantir o cumprimento dos requisitos listados no [readme](https://github.com/helenapato/backend-test#5---sua-aplica%C3%A7%C3%A3o-deve-ter-o-endpoint-delete-userme) do projeto.