### PR TITLE
[LEARN 4428] Criando e testando o endpoint POST /post

### DIFF
--- a/api_blogs/README.md
+++ b/api_blogs/README.md
@@ -34,6 +34,10 @@ Instruções para instalar e configurar o projeto em seu computador.
 Para rodar os testes do user controller, use o comando abaixo, dentro da pasta `api_blogs`
 
 	mix test test/api_blogs_web/controllers/user_controller_test.exs
+
+Para rodar os testes do post controller, use o comando abaixo, dentro da pasta `api_blogs`
+
+	mix test test/api_blogs_web/controllers/post_controller_test.exs
 Para testar manualmente, inicie o servidor com 
 
 	mix phx.server

--- a/api_blogs/lib/api_blogs/blog/post.ex
+++ b/api_blogs/lib/api_blogs/blog/post.ex
@@ -2,13 +2,11 @@ defmodule ApiBlogs.Blog.Post do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @fields ~w(title content published updated user_id)a
+  @fields ~w(title content user_id)a
 
   schema "posts" do
     field :content, :string
-    field :published, :naive_datetime
     field :title, :string
-    field :updated, :naive_datetime
     field :user_id, :id
 
     timestamps()

--- a/api_blogs/lib/api_blogs/blog/post.ex
+++ b/api_blogs/lib/api_blogs/blog/post.ex
@@ -2,6 +2,8 @@ defmodule ApiBlogs.Blog.Post do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @fields ~w(title content published updated user_id)a
+
   schema "posts" do
     field :content, :string
     field :published, :naive_datetime
@@ -15,8 +17,8 @@ defmodule ApiBlogs.Blog.Post do
   @doc false
   def changeset(post, attrs) do
     post
-    |> cast(attrs, [:title, :content, :published, :updated, :user_id])
-    |> validate_required([:title, :content, :published, :updated])
+    |> cast(attrs, @fields)
+    |> validate_required(@fields)
     |> foreign_key_constraint(:user_id)
   end
 end

--- a/api_blogs/lib/api_blogs/blog/post.ex
+++ b/api_blogs/lib/api_blogs/blog/post.ex
@@ -15,7 +15,7 @@ defmodule ApiBlogs.Blog.Post do
   @doc false
   def changeset(post, attrs) do
     post
-    |> cast(attrs, [:title, :content, :published, :updated])
+    |> cast(attrs, [:title, :content, :published, :updated, :user_id])
     |> validate_required([:title, :content, :published, :updated])
     |> foreign_key_constraint(:user_id)
   end

--- a/api_blogs/lib/api_blogs/blog/user.ex
+++ b/api_blogs/lib/api_blogs/blog/user.ex
@@ -2,6 +2,9 @@ defmodule ApiBlogs.Blog.User do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @fields ~w(displayName email password image)a
+  @required_fields ~w(email password)a
+
   schema "users" do
     field :displayName, :string
     field :email, :string
@@ -14,8 +17,8 @@ defmodule ApiBlogs.Blog.User do
   @doc false
   def changeset(user, attrs) do
     user
-    |> cast(attrs, [:displayName, :email, :password, :image])
-    |> validate_required([:email, :password])
+    |> cast(attrs, @fields)
+    |> validate_required(@required_fields)
     |> unique_constraint(:email, message: "Usuario ja existe")
     |> validate_format(:email, ~r/.@./)
     |> validate_length(:displayName, min: 8)

--- a/api_blogs/lib/api_blogs_web/controllers/fallback_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/fallback_controller.ex
@@ -53,4 +53,11 @@ defmodule ApiBlogsWeb.FallbackController do
     |> put_view(ApiBlogsWeb.ErrorView)
     |> json(%{message: "Usuario nao existe"})
   end
+
+  def call(conn, {:error, :missing_title_content}) do
+    conn
+    |> put_status(:bad_request)
+    |> put_view(ApiBlogsWeb.ErrorView)
+    |> json(%{message: "title and content are required"})
+  end
 end

--- a/api_blogs/lib/api_blogs_web/controllers/fallback_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/fallback_controller.ex
@@ -53,11 +53,4 @@ defmodule ApiBlogsWeb.FallbackController do
     |> put_view(ApiBlogsWeb.ErrorView)
     |> json(%{message: "Usuario nao existe"})
   end
-
-  def call(conn, {:error, :missing_title_content}) do
-    conn
-    |> put_status(:bad_request)
-    |> put_view(ApiBlogsWeb.ErrorView)
-    |> json(%{message: "title and content are required"})
-  end
 end

--- a/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
@@ -12,27 +12,15 @@ defmodule ApiBlogsWeb.PostController do
     render(conn, "index.json", posts: posts)
   end
 
-  def create(conn, %{"post" => %{"content" => content, "title" => title}}) do
+  def create(conn, %{"post" => post_params}) do
     {:ok, %{"sub" => id}} = UserController.extract_id(conn)
-    time_now = NaiveDateTime.utc_now()
-
-    new_post = %{
-      "content" => content,
-      "published" => time_now,
-      "title" => title,
-      "updated" => time_now,
-      "user_id" => id
-    }
+    new_post = Map.put(post_params, "user_id", id)
 
     with {:ok, %Post{} = post} <- Blog.create_post(new_post) do
       conn
       |> put_status(:created)
       |> render("create.json", post: post)
     end
-  end
-
-  def create(_conn, %{"post" => _post_params}) do
-    {:error, :missing_title_content}
   end
 
   def show(conn, %{"id" => id}) do

--- a/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
@@ -46,7 +46,7 @@ defmodule ApiBlogsWeb.UserController do
       end
   end
 
-  defp extract_id(conn) do
+  def extract_id(conn) do
     conn.private[:guardian_default_token]
     |> Guardian.decode_and_verify()
   end

--- a/api_blogs/lib/api_blogs_web/router.ex
+++ b/api_blogs/lib/api_blogs_web/router.ex
@@ -31,7 +31,9 @@ defmodule ApiBlogsWeb.Router do
     pipe_through :api
 
     #resources "/users", UserController, except: [:new, :edit]
-    resources "/posts", PostController, except: [:new, :edit]
+    #resources "/posts", PostController, except: [:new, :edit]
+    get "/post", PostController, :index
+    get "/post/:id", PostController, :show
 
     post "/user", UserController, :create
     post "/login", UserController, :login
@@ -43,6 +45,8 @@ defmodule ApiBlogsWeb.Router do
     get "/user", UserController, :index
     get "/user/:id", UserController, :show
     delete "/user/me", UserController, :delete
+
+    post "/post", PostController, :create
   end
 
   # Enables LiveDashboard only for development

--- a/api_blogs/lib/api_blogs_web/views/post_view.ex
+++ b/api_blogs/lib/api_blogs_web/views/post_view.ex
@@ -19,4 +19,12 @@ defmodule ApiBlogsWeb.PostView do
       updated: post.updated
     }
   end
+
+  def render("create.json", %{post: post}) do
+    %{
+      title: post.title,
+      content: post.content,
+      user_id: post.user_id
+    }
+  end
 end

--- a/api_blogs/priv/repo/migrations/20220222185115_create_posts.exs
+++ b/api_blogs/priv/repo/migrations/20220222185115_create_posts.exs
@@ -5,8 +5,6 @@ defmodule ApiBlogs.Repo.Migrations.CreatePosts do
     create table(:posts) do
       add :title, :string
       add :content, :string
-      add :published, :naive_datetime
-      add :updated, :naive_datetime
       add :user_id, references(:users, on_delete: :nothing)
 
       timestamps()

--- a/api_blogs/priv/repo/migrations/20220322121300_drop_published_updated.exs
+++ b/api_blogs/priv/repo/migrations/20220322121300_drop_published_updated.exs
@@ -1,0 +1,10 @@
+defmodule ApiBlogs.Repo.Migrations.DropPublishedUpdated do
+  use Ecto.Migration
+
+  def change do
+    alter table("posts") do
+      remove :published, :naive_datetime
+      remove :updated, :naive_datetime
+    end
+  end
+end

--- a/api_blogs/test/api_blogs_web/controllers/post_controller_test.exs
+++ b/api_blogs/test/api_blogs_web/controllers/post_controller_test.exs
@@ -35,7 +35,7 @@ defmodule ApiBlogsWeb.PostControllerTest do
   # end
 
   describe "create post" do
-    setup [:create_user]
+    setup [:add_user_jwt]
 
     test "renders post when data is valid", %{conn: conn, jwt: jwt} do
       conn =
@@ -126,10 +126,14 @@ defmodule ApiBlogsWeb.PostControllerTest do
   #   %{post: post}
   # end
 
-  defp create_user %{conn: conn} do
+  defp add_user_jwt %{conn: conn} do
     conn = post(conn, Routes.user_path(conn, :create), user: @user_create_attrs)
+    {:ok, conn: build_conn(), jwt: get_jwt_from_conn_header(conn)}
+  end
+
+  defp get_jwt_from_conn_header(conn) do
     [_ | [_ | [_ | [jwt | _]]]] = String.split(conn.resp_body, "\"")
-    {:ok, conn: build_conn(), jwt: jwt}
+    jwt
   end
 
   defp put_invalid_jwt_header(conn) do

--- a/api_blogs/test/api_blogs_web/controllers/post_controller_test.exs
+++ b/api_blogs/test/api_blogs_web/controllers/post_controller_test.exs
@@ -56,7 +56,7 @@ defmodule ApiBlogsWeb.PostControllerTest do
         conn
         |> put_valid_jwt_header(jwt)
         |> post(Routes.post_path(conn, :create), post: invalid_attrs)
-      assert %{"message" => "title and content are required"} = json_response(conn, 400)
+      assert %{"errors" => %{"title" => ["can't be blank"]}} = json_response(conn, 400)
     end
 
     test "renders errors when no content is provided", %{conn: conn, jwt: jwt} do
@@ -67,7 +67,7 @@ defmodule ApiBlogsWeb.PostControllerTest do
         conn
         |> put_valid_jwt_header(jwt)
         |> post(Routes.post_path(conn, :create), post: invalid_attrs)
-      assert %{"message" => "title and content are required"} = json_response(conn, 400)
+      assert %{"errors" => %{"content" => ["can't be blank"]}} = json_response(conn, 400)
     end
 
     test "renders errors when jwt is invalid", %{conn: conn} do

--- a/api_blogs/test/api_blogs_web/controllers/user_controller_test.exs
+++ b/api_blogs/test/api_blogs_web/controllers/user_controller_test.exs
@@ -23,72 +23,65 @@ defmodule ApiBlogsWeb.UserControllerTest do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
-  describe "index" do
-    test "lists all users", %{conn: conn} do
+  describe "list all users" do
+    test "renders two users", %{conn: conn} do
       new_user = %{
         displayName: "maria silva",
         email: "maria@email.com",
         password: "654321"
       }
 
-      conn = conn
-      |> post(Routes.user_path(conn, :create), user: @create_attrs)
-      |> post(Routes.user_path(conn, :create), user: new_user)
-
-      split_response_body = String.split(conn.resp_body, "\"")
-      [_ | [_ | [_ | [jwt | _]]]] = split_response_body
+      conn =
+        conn
+        |> post(Routes.user_path(conn, :create), user: @create_attrs)
+        |> post(Routes.user_path(conn, :create), user: new_user)
 
       conn =
-      build_conn()
-      |> put_req_header("authorization", "bearer " <> jwt)
-      |> get(Routes.user_path(conn, :index))
+        build_conn()
+        |> put_valid_jwt_header(get_jwt_from_conn_header(conn))
+        |> get(Routes.user_path(conn, :index))
 
-      response_data = json_response(conn, 200)["data"]
-      assert hd(response_data)["email"] == "rubens@email.com"
-      assert hd(tl(response_data))["email"] == "maria@email.com"
+      assert %{"data" => [ %{"email" => "rubens@email.com"} | [ %{"email" => "maria@email.com"} | _ ]]} = json_response(conn, 200)
     end
 
-    test "lists all users invalid jwt", %{conn: conn} do
+    test "renders errors when jwt is invalid", %{conn: conn} do
       conn =
-      conn
-      |> put_req_header("authorization", "bearer abcd")
-      |> get(Routes.user_path(conn, :index))
+        conn
+        |> put_invalid_jwt_header()
+        |> get(Routes.user_path(conn, :index))
 
-      assert json_response(conn, 401) == %{"message" => "Token expirado ou invalido"}
+      assert %{"message" => "Token expirado ou invalido"} = json_response(conn, 401)
     end
 
-    test "lists all users missing jwt", %{conn: conn} do
+    test "renders errors when jwt is missing", %{conn: conn} do
       conn = get(conn, Routes.user_path(conn, :index))
-      assert json_response(conn, 401) == %{"message" => "Token nao encontrado"}
+      assert %{"message" => "Token nao encontrado"} = json_response(conn, 401)
     end
   end
 
   describe "create user" do
-    test "renders user when data is valid", %{conn: conn} do
+    test "renders jwt when data is valid", %{conn: conn} do
       conn = post(conn, Routes.user_path(conn, :create), user: @create_attrs)
-      assert nil != json_response(conn, 201)["jwt"]
-
-      split_response_body = String.split(conn.resp_body, "\"")
-      [_ | [_ | [_ | [jwt | _]]]] = split_response_body
+      assert %{"jwt" => _} = json_response(conn, 201)
 
       conn =
-      build_conn()
-      |> put_req_header("authorization", "bearer " <> jwt)
-      |> get(Routes.user_path(conn, :index))
+        build_conn()
+        |> put_valid_jwt_header(get_jwt_from_conn_header(conn))
+        |> get(Routes.user_path(conn, :index))
 
-      response_data = json_response(conn, 200)["data"]
-      id = hd(response_data)["id"]
+      assert %{"data" => [%{"id" => id}]} = json_response(conn, 200)
 
       conn = get(conn, Routes.user_path(conn, :show, id))
-      response_data = json_response(conn, 200)["data"]
 
-      assert %{
-               "id" => ^id,
-               "displayName" => "rubens silva",
-               "email" => "rubens@email.com",
-               "image" => "http://4.bp.blogspot.com/_YA50adQ-7vQ/S1gfR_6ufpI/AAAAAAAAAAk/1ErJGgRWZDg/S45/brett.png",
-               "password" => "123456"
-             } = response_data
+      assert %{"data" =>
+                %{
+                  "id" => ^id,
+                  "displayName" => "rubens silva",
+                  "email" => "rubens@email.com",
+                  "image" => "http://4.bp.blogspot.com/_YA50adQ-7vQ/S1gfR_6ufpI/AAAAAAAAAAk/1ErJGgRWZDg/S45/brett.png",
+                  "password" => "123456"
+                }
+              } = json_response(conn, 200)
     end
 
     test "renders errors when displayName has less than 8 characters", %{conn: conn} do
@@ -99,7 +92,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: "123456"
       }
       conn = post(conn, Routes.user_path(conn, :create), user: invalid_user)
-      assert json_response(conn, 400)["errors"] == %{"displayName" => ["should be at least 8 character(s)"]}
+      assert %{"errors" => %{"displayName" => ["should be at least 8 character(s)"]}} = json_response(conn, 400)
     end
 
     test "renders errors when email has no domain", %{conn: conn} do
@@ -110,7 +103,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: "123456"
       }
       conn = post(conn, Routes.user_path(conn, :create), user: invalid_user)
-      assert json_response(conn, 400)["errors"] == %{"email" => ["has invalid format"]}
+      assert %{"errors" => %{"email" => ["has invalid format"]}} = json_response(conn, 400)
     end
 
     test "renders errors when email has no prefix", %{conn: conn} do
@@ -121,7 +114,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: "123456"
       }
       conn = post(conn, Routes.user_path(conn, :create), user: invalid_user)
-      assert json_response(conn, 400)["errors"] == %{"email" => ["has invalid format"]}
+      assert %{"errors" => %{"email" => ["has invalid format"]}} = json_response(conn, 400)
     end
 
     test "renders errors when no email is provided", %{conn: conn} do
@@ -131,7 +124,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: "123456"
       }
       conn = post(conn, Routes.user_path(conn, :create), user: invalid_user)
-      assert json_response(conn, 400)["errors"] == %{"email" => ["can't be blank"]}
+      assert %{"errors" => %{"email" => ["can't be blank"]}} = json_response(conn, 400)
     end
 
     test "renders errors when password is less than 6 characters long", %{conn: conn} do
@@ -142,7 +135,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: "12345"
       }
       conn = post(conn, Routes.user_path(conn, :create), user: invalid_user)
-      assert json_response(conn, 400)["errors"] == %{"password" => ["should be at least 6 character(s)"]}
+      assert %{"errors" => %{"password" => ["should be at least 6 character(s)"]}} = json_response(conn, 400)
     end
 
     test "renders errors when no password is provided", %{conn: conn} do
@@ -152,60 +145,58 @@ defmodule ApiBlogsWeb.UserControllerTest do
         image: "http://4.bp.blogspot.com/_YA50adQ-7vQ/S1gfR_6ufpI/AAAAAAAAAAk/1ErJGgRWZDg/S45/brett.png"
       }
       conn = post(conn, Routes.user_path(conn, :create), user: invalid_user)
-      assert json_response(conn, 400)["errors"] == %{"password" => ["can't be blank"]}
+      assert %{"errors" => %{"password" => ["can't be blank"]}} = json_response(conn, 400)
     end
 
-    test "renders errors when email already exists", %{conn: conn} do
+    test "renders errors when email already exists in database", %{conn: conn} do
       conn = post(conn, Routes.user_path(conn, :create), user: @create_attrs)
-      assert nil != json_response(conn, 201)["jwt"]
+      assert %{"jwt" => _} = json_response(conn, 201)
 
       conn = post(conn, Routes.user_path(conn, :create), user: @create_attrs)
-      assert json_response(conn, 409)["errors"] == %{"email" => ["Usuario ja existe"]}
+      assert %{"errors" => %{"email" => ["Usuario ja existe"]}} = json_response(conn, 409)
     end
   end
 
   describe "get user by id" do
-    setup [:add_user]
+    setup [:add_user_jwt]
 
-    test "returns correct user info", %{conn: conn, jwt: jwt} do
+    test "renders user info", %{conn: conn, jwt: jwt} do
       conn =
-      build_conn()
-      |> put_req_header("authorization", "bearer " <> jwt)
-      |> get(Routes.user_path(conn, :index))
+        conn
+        |> put_valid_jwt_header(jwt)
+        |> get(Routes.user_path(conn, :index))
 
-      response_data = json_response(conn, 200)["data"]
-      id = hd(response_data)["id"]
+      assert %{"data" => [%{"id" => id}]} = json_response(conn, 200)
 
       conn = get(conn, Routes.user_path(conn, :show, id))
-      response_data = json_response(conn, 200)["data"]
-      assert response_data["email"] == "rubens@email.com"
+      assert %{"data" => %{"email" => "rubens@email.com"}} = json_response(conn, 200)
     end
 
-    test "returns error for nonexistent user", %{conn: conn, jwt: jwt} do
+    test "renders errors when user doesn't exist", %{conn: conn, jwt: jwt} do
       conn =
-      build_conn()
-      |> put_req_header("authorization", "bearer " <> jwt)
-      |> get(Routes.user_path(conn, :index))
+        conn
+        |> put_valid_jwt_header(jwt)
+        |> get(Routes.user_path(conn, :index))
 
-      response_data = json_response(conn, 200)["data"]
-      id = hd(response_data)["id"] + 1
+      assert %{"data" => [%{"id" => id}]} = json_response(conn, 200)
+      invalid_id = id + 1
 
-      conn = get(conn, Routes.user_path(conn, :show, id))
-      assert json_response(conn, 404) == %{"message" => "Usuario nao existe"}
+      conn = get(conn, Routes.user_path(conn, :show, invalid_id))
+      assert %{"message" => "Usuario nao existe"} = json_response(conn, 404)
     end
 
-    test "returns error for invalid jwt", %{conn: conn} do
+    test "renders errors when jwt is invalid", %{conn: conn} do
       conn =
-      build_conn()
-      |> put_req_header("authorization", "bearer abcd")
-      |> get(Routes.user_path(conn, :show, 1))
+        conn
+        |> put_invalid_jwt_header()
+        |> get(Routes.user_path(conn, :show, 1))
 
-      assert json_response(conn, 401) == %{"message" => "Token expirado ou invalido"}
+      assert %{"message" => "Token expirado ou invalido"} = json_response(conn, 401)
     end
 
-    test "returns error for missing jwt", %{conn: conn} do
+    test "renders errors when jwt is missing", %{conn: conn} do
       conn = get(conn, Routes.user_path(conn, :show, 1))
-      assert json_response(conn, 401) == %{"message" => "Token nao encontrado"}
+      assert %{"message" => "Token nao encontrado"} = json_response(conn, 401)
     end
   end
 
@@ -234,42 +225,42 @@ defmodule ApiBlogsWeb.UserControllerTest do
   # end
 
   describe "delete user" do
-    setup [:add_user]
+    setup [:add_user_jwt]
 
-    test "successfull delete", %{conn: conn, jwt: jwt} do
+    test "renders deleted user", %{conn: conn, jwt: jwt} do
       conn =
-      build_conn()
-      |> put_req_header("authorization", "bearer " <> jwt)
-      |> delete(Routes.user_path(conn, :delete))
+        conn
+        |> put_valid_jwt_header(jwt)
+        |> delete(Routes.user_path(conn, :delete))
 
-      assert response(conn, 204) == ""
+      assert "" = response(conn, 204)
     end
 
-    test "returns error for invalid jwt", %{conn: conn} do
+    test "renders errors when jwt is invalid", %{conn: conn} do
       conn =
-      build_conn()
-      |> put_req_header("authorization", "bearer abcd")
-      |> delete(Routes.user_path(conn, :delete))
+        conn
+        |> put_invalid_jwt_header()
+        |> delete(Routes.user_path(conn, :delete))
 
-      assert json_response(conn, 401) == %{"message" => "Token expirado ou invalido"}
+      assert %{"message" => "Token expirado ou invalido"} = json_response(conn, 401)
     end
 
-    test "returns error for missing jwt", %{conn: conn} do
+    test "renders errors when jwt is missing", %{conn: conn} do
       conn = delete(conn, Routes.user_path(conn, :delete))
-      assert json_response(conn, 401) == %{"message" => "Token nao encontrado"}
+      assert %{"message" => "Token nao encontrado"} = json_response(conn, 401)
     end
   end
 
   describe "user login" do
     setup [:add_user]
 
-    test "returns jwt when data is valid", %{conn: conn} do
+    test "renders jwt when data is valid", %{conn: conn} do
       valid_attrs = %{
         email: "rubens@email.com",
         password: "123456"
       }
       conn = post(conn, Routes.user_path(conn, :login), user: valid_attrs)
-      assert nil != json_response(conn, 200)["jwt"]
+      assert %{"jwt" => _} = json_response(conn, 200)
     end
 
     test "renders errors when no email is provided", %{conn: conn} do
@@ -277,7 +268,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: "123456"
       }
       conn = post(conn, Routes.user_path(conn, :login), user: invalid_attrs)
-      assert json_response(conn, 400) == %{"message" => "email and password are required"}
+      assert %{"message" => "email and password are required"} = json_response(conn, 400)
     end
 
     test "renders errors when no password is provided", %{conn: conn} do
@@ -285,7 +276,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         email: "rubens@email.com"
       }
       conn = post(conn, Routes.user_path(conn, :login), user: invalid_attrs)
-      assert json_response(conn, 400) == %{"message" => "email and password are required"}
+      assert %{"message" => "email and password are required"} = json_response(conn, 400)
     end
 
     test "renders errors when email is blank", %{conn: conn} do
@@ -294,7 +285,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: "123456"
       }
       conn = post(conn, Routes.user_path(conn, :login), user: invalid_attrs)
-      assert json_response(conn, 400) == %{"message" => "email and password are required"}
+      assert %{"message" => "email and password are required"} = json_response(conn, 400)
     end
 
     test "renders errors when password is blank", %{conn: conn} do
@@ -303,7 +294,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: ""
       }
       conn = post(conn, Routes.user_path(conn, :login), user: invalid_attrs)
-      assert json_response(conn, 400) == %{"message" => "email and password are required"}
+      assert %{"message" => "email and password are required"} = json_response(conn, 400)
     end
 
     test "renders errors when password is wrong", %{conn: conn} do
@@ -312,7 +303,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: "1234567"
       }
       conn = post(conn, Routes.user_path(conn, :login), user: invalid_attrs)
-      assert json_response(conn, 400) == %{"message" => "Campos invalidos"}
+      assert %{"message" => "Campos invalidos"} = json_response(conn, 400)
     end
 
     test "renders errors when user doesn't exist", %{conn: conn} do
@@ -321,7 +312,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: "1234567"
       }
       conn = post(conn, Routes.user_path(conn, :login), user: invalid_attrs)
-      assert json_response(conn, 400) == %{"message" => "Campos invalidos"}
+      assert %{"message" => "Campos invalidos"} = json_response(conn, 400)
     end
   end
 
@@ -331,9 +322,24 @@ defmodule ApiBlogsWeb.UserControllerTest do
   # end
 
   defp add_user %{conn: conn} do
+    {:ok, conn: post(conn, Routes.user_path(conn, :create), user: @create_attrs)}
+  end
+
+  defp add_user_jwt %{conn: conn} do
     conn = post(conn, Routes.user_path(conn, :create), user: @create_attrs)
-    split_response_body = String.split(conn.resp_body, "\"")
-    [_ | [_ | [_ | [jwt | _]]]] = split_response_body
-    {:ok, conn: conn, jwt: jwt}
+    {:ok, conn: build_conn(), jwt: get_jwt_from_conn_header(conn)}
+  end
+
+  defp get_jwt_from_conn_header(conn) do
+    [_ | [_ | [_ | [jwt | _]]]] = String.split(conn.resp_body, "\"")
+    jwt
+  end
+
+  defp put_invalid_jwt_header(conn) do
+    put_req_header(conn, "authorization", "bearer abcd")
+  end
+
+  defp put_valid_jwt_header(conn, jwt) do
+    put_req_header(conn, "authorization", "bearer " <> jwt)
   end
 end


### PR DESCRIPTION
[Link da tarefa no Jira](https://trybe.atlassian.net/jira/software/c/projects/LEARN/boards/56?modal=detail&selectedIssue=LEARN-4428&assignee=61eed0dd25edab006afb4305)

A API de blogs deve ter um endpoint capaz de adicionar um post no banco de dados, dado o token JWT do usuário.

Foi criada uma nova rota no router, e a função original de criar um post, gerada pelo comando

`mix phx.gen.json Blog Post posts title content user_id:references:users published:datetime updated:datetime`

foi modificada para receber somente o título e conteúdo do post, além do token JWT do usuário no header da requisição. Com essas informações, criamos um novo mapa para o post que será adicionado, completo com o ID do usuário (obtido do token, usando uma função já definida em UserController) e o horário atual. Caso o título ou conteúdo esteja faltando, mandamos um erro para o FallbackController. Além disso, foram criados testes para garantir o cumprimento dos requisitos listados no [readme](https://github.com/helenapato/backend-test#6---sua-aplica%C3%A7%C3%A3o-deve-ter-o-endpoint-post-post) do projeto.

Os testes de UserController foram melhorados, levando em conta os feedbacks fornecidos no último PR, e aumentando a padronização.