### PR TITLE
[LEARN-4478] Criando e testando endpoint GET /post

### DIFF
--- a/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
@@ -8,8 +8,17 @@ defmodule ApiBlogsWeb.PostController do
   action_fallback ApiBlogsWeb.FallbackController
 
   def index(conn, _params) do
-    posts = Blog.list_posts()
-    render(conn, "index.json", posts: posts)
+    posts_users =
+      Blog.list_posts()
+      |> get_post_user()
+    render(conn, "index.json", posts_users: posts_users)
+  end
+
+  defp get_post_user([]), do: []
+  defp get_post_user([post | posts]) do
+    with user <- Blog.get_user!(post.user_id) do
+      [ %{post: post, user: user} | get_post_user(posts)]
+    end
   end
 
   def create(conn, %{"post" => post_params}) do

--- a/api_blogs/lib/api_blogs_web/router.ex
+++ b/api_blogs/lib/api_blogs_web/router.ex
@@ -32,8 +32,8 @@ defmodule ApiBlogsWeb.Router do
 
     #resources "/users", UserController, except: [:new, :edit]
     #resources "/posts", PostController, except: [:new, :edit]
-    get "/post", PostController, :index
     get "/post/:id", PostController, :show
+    delete "/post/:id", PostController, :delete
 
     post "/user", UserController, :create
     post "/login", UserController, :login
@@ -47,6 +47,7 @@ defmodule ApiBlogsWeb.Router do
     delete "/user/me", UserController, :delete
 
     post "/post", PostController, :create
+    get "/post", PostController, :index
   end
 
   # Enables LiveDashboard only for development

--- a/api_blogs/lib/api_blogs_web/router.ex
+++ b/api_blogs/lib/api_blogs_web/router.ex
@@ -30,24 +30,17 @@ defmodule ApiBlogsWeb.Router do
   scope "/api", ApiBlogsWeb do
     pipe_through :api
 
-    #resources "/users", UserController, except: [:new, :edit]
-    #resources "/posts", PostController, except: [:new, :edit]
-    get "/post/:id", PostController, :show
-    delete "/post/:id", PostController, :delete
-
-    post "/user", UserController, :create
+    resources "/user", UserController, only: [:create]
     post "/login", UserController, :login
   end
 
   scope "/api", ApiBlogsWeb do
     pipe_through [:api, :jwt_authenticated]
 
-    get "/user", UserController, :index
-    get "/user/:id", UserController, :show
+    resources "/user", UserController, only: [:index, :show]
     delete "/user/me", UserController, :delete
 
-    post "/post", PostController, :create
-    get "/post", PostController, :index
+    resources "/post", PostController, only: [:create, :index, :show, :update, :delete]
   end
 
   # Enables LiveDashboard only for development

--- a/api_blogs/lib/api_blogs_web/views/post_view.ex
+++ b/api_blogs/lib/api_blogs_web/views/post_view.ex
@@ -1,7 +1,6 @@
 defmodule ApiBlogsWeb.PostView do
   use ApiBlogsWeb, :view
   alias ApiBlogsWeb.PostView
-  alias ApiBlogs.Blog
 
   def render("index.json", %{posts_users: posts_users}) do
     %{data: render_many(posts_users, PostView, "post.json")}

--- a/api_blogs/lib/api_blogs_web/views/post_view.ex
+++ b/api_blogs/lib/api_blogs_web/views/post_view.ex
@@ -1,6 +1,7 @@
 defmodule ApiBlogsWeb.PostView do
   use ApiBlogsWeb, :view
   alias ApiBlogsWeb.PostView
+  alias ApiBlogs.Blog
 
   def render("index.json", %{posts: posts}) do
     %{data: render_many(posts, PostView, "post.json")}
@@ -11,13 +12,21 @@ defmodule ApiBlogsWeb.PostView do
   end
 
   def render("post.json", %{post: post}) do
-    %{
-      id: post.id,
-      title: post.title,
-      content: post.content,
-      published: post.published,
-      updated: post.updated
-    }
+    with user <- Blog.get_user!(post.user_id) do
+      %{
+        id: post.id,
+        title: post.title,
+        content: post.content,
+        published: post.inserted_at,
+        updated: post.updated_at,
+        user: %{
+          id: user.id,
+          displayName: user.displayName,
+          email: user.email,
+          image: user.image
+        }
+      }
+    end
   end
 
   def render("create.json", %{post: post}) do

--- a/api_blogs/lib/api_blogs_web/views/post_view.ex
+++ b/api_blogs/lib/api_blogs_web/views/post_view.ex
@@ -3,30 +3,32 @@ defmodule ApiBlogsWeb.PostView do
   alias ApiBlogsWeb.PostView
   alias ApiBlogs.Blog
 
-  def render("index.json", %{posts: posts}) do
-    %{data: render_many(posts, PostView, "post.json")}
+  def render("index.json", %{posts_users: posts_users}) do
+    %{data: render_many(posts_users, PostView, "post.json")}
   end
 
   def render("show.json", %{post: post}) do
     %{data: render_one(post, PostView, "post.json")}
   end
 
-  def render("post.json", %{post: post}) do
-    with user <- Blog.get_user!(post.user_id) do
-      %{
-        id: post.id,
-        title: post.title,
-        content: post.content,
-        published: post.inserted_at,
-        updated: post.updated_at,
-        user: %{
-          id: user.id,
-          displayName: user.displayName,
-          email: user.email,
-          image: user.image
-        }
-      }
-    end
+  def render("post.json", %{post: %{post: post, user: user}}) do
+    %{
+      id: post.id,
+      title: post.title,
+      content: post.content,
+      published: post.inserted_at,
+      updated: post.updated_at,
+      user: render("user.json", %{user: user})
+    }
+  end
+
+  def render("user.json", %{user: user}) do
+    %{
+      id: user.id,
+      displayName: user.displayName,
+      email: user.email,
+      image: user.image
+    }
   end
 
   def render("create.json", %{post: post}) do


### PR DESCRIPTION
[Link da tarefa no Jira](https://trybe.atlassian.net/jira/software/c/projects/LEARN/boards/56?modal=detail&selectedIssue=LEARN-4478&assignee=61eed0dd25edab006afb4305)

A API de blogs deve ter um _endpoint_ capaz de listar todos os _posts_ cadastrados no banco de dados, juntamente com os seus respectivos usuários autores, desde que um token JWT válido esteja presente no _header_ da requisição.

Foi criada uma nova rota no `router`, e a `view` usada para listar um _post_ for modificada para incluir as informações do usuário autor. Além disso, foram criados testes para garantir o cumprimento dos requisitos listados no [readme](https://github.com/helenapato/backend-test#7---sua-aplica%C3%A7%C3%A3o-deve-ter-o-endpoint-get-post) do projeto.
