### PR TITLE
[LEARN-4495] Criando e testando o endpoint GET /post/:id

### DIFF
--- a/api_blogs/lib/api_blogs/blog.ex
+++ b/api_blogs/lib/api_blogs/blog.ex
@@ -204,18 +204,15 @@ defmodule ApiBlogs.Blog do
   def do_login(%{"email" => "", "password" => _password}), do: {:error, :bad_request, "\"email\" is not allowed to be empty"}
   def do_login(%{"email" => _email, "password" => ""}), do: {:error, :bad_request, "\"password\" is not allowed to be empty"}
   def do_login(%{"email" => email, "password" => password}) do
-    user = Repo.get_by(User, email: email)
-    if user == nil do
-      {:error, :bad_request, "Campos invalidos"}
-    else
-      if user.password != password do
-        {:error, :bad_request, "Campos invalidos"}
-      else
-        {:ok, user}
-      end
-    end
+    User
+    |> Repo.get_by(email: email)
+    |> validate_login(password)
   end
   def do_login(%{"email" => _email}), do: {:error, :bad_request, "\"password\" is required"}
   def do_login(%{"password" => _password}), do: {:error, :bad_request, "\"email\" is required"}
+
+  defp validate_login(nil, _password), do: {:error, :bad_request, "Campos invalidos"}
+  defp validate_login(user, password) when user.password != password, do: {:error, :bad_request, "Campos invalidos"}
+  defp validate_login(user, _password), do: {:ok, user}
 
 end

--- a/api_blogs/lib/api_blogs/blog.ex
+++ b/api_blogs/lib/api_blogs/blog.ex
@@ -36,6 +36,7 @@ defmodule ApiBlogs.Blog do
 
   """
   def get_user!(id), do: Repo.get!(User, id)
+  def get_user(id), do: Repo.get(User, id)
 
   @doc """
   Creates a user.
@@ -132,6 +133,7 @@ defmodule ApiBlogs.Blog do
 
   """
   def get_post!(id), do: Repo.get!(Post, id)
+  def get_post(id), do: Repo.get(Post, id)
 
   @doc """
   Creates a post.

--- a/api_blogs/lib/api_blogs/blog.ex
+++ b/api_blogs/lib/api_blogs/blog.ex
@@ -201,19 +201,21 @@ defmodule ApiBlogs.Blog do
   @doc """
   User login.
   """
-  def do_login(%{"email" => "", "password" => _password}) do {:error, :login_missing_info} end
-  def do_login(%{"email" => _email, "password" => ""}) do {:error, :login_missing_info} end
+  def do_login(%{"email" => "", "password" => _password}), do: {:error, :bad_request, "\"email\" is not allowed to be empty"}
+  def do_login(%{"email" => _email, "password" => ""}), do: {:error, :bad_request, "\"password\" is not allowed to be empty"}
   def do_login(%{"email" => email, "password" => password}) do
     user = Repo.get_by(User, email: email)
     if user == nil do
-      {:error, :login_invalid_entry}
+      {:error, :bad_request, "Campos invalidos"}
     else
       if user.password != password do
-        {:error, :login_invalid_entry}
+        {:error, :bad_request, "Campos invalidos"}
       else
         {:ok, user}
       end
     end
   end
-  def do_login(_attrs) do {:error, :login_missing_info} end
+  def do_login(%{"email" => _email}), do: {:error, :bad_request, "\"password\" is required"}
+  def do_login(%{"password" => _password}), do: {:error, :bad_request, "\"email\" is required"}
+
 end

--- a/api_blogs/lib/api_blogs_web/controllers/fallback_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/fallback_controller.ex
@@ -26,38 +26,18 @@ defmodule ApiBlogsWeb.FallbackController do
   end
 
   # This clause is an example of how to handle resources that cannot be found.
+
+  def call(conn, {:error, error, message}) do
+    conn
+    |> put_status(error)
+    |> put_view(ApiBlogsWeb.ErrorView)
+    |> json(%{message: message})
+  end
+
   def call(conn, {:error, :not_found}) do
     conn
     |> put_status(:not_found)
     |> put_view(ApiBlogsWeb.ErrorView)
     |> render(:"404")
-  end
-
-  def call(conn, {:error, :login_invalid_entry}) do
-    conn
-    |> put_status(:bad_request)
-    |> put_view(ApiBlogsWeb.ErrorView)
-    |> json(%{message: "Campos invalidos"})
-  end
-
-  def call(conn, {:error, :login_missing_info}) do
-    conn
-    |> put_status(:bad_request)
-    |> put_view(ApiBlogsWeb.ErrorView)
-    |> json(%{message: "email and password are required"})
-  end
-
-  def call(conn, {:error, :nonexistent_user}) do
-    conn
-    |> put_status(:not_found)
-    |> put_view(ApiBlogsWeb.ErrorView)
-    |> json(%{message: "Usuario nao existe"})
-  end
-
-  def call(conn, {:error, :nonexistent_post}) do
-    conn
-    |> put_status(:not_found)
-    |> put_view(ApiBlogsWeb.ErrorView)
-    |> json(%{message: "Post nao existe"})
   end
 end

--- a/api_blogs/lib/api_blogs_web/controllers/fallback_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/fallback_controller.ex
@@ -53,4 +53,11 @@ defmodule ApiBlogsWeb.FallbackController do
     |> put_view(ApiBlogsWeb.ErrorView)
     |> json(%{message: "Usuario nao existe"})
   end
+
+  def call(conn, {:error, :nonexistent_post}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(ApiBlogsWeb.ErrorView)
+    |> json(%{message: "Post nao existe"})
+  end
 end

--- a/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
@@ -38,16 +38,13 @@ defmodule ApiBlogsWeb.PostController do
   end
 
   def show(conn, %{"id" => id}) do
-    try do
-      post_user =
-        id
-        |> Blog.get_post!()
-        |> get_post_user()
-      render(conn, "show.json", post_user: post_user)
-    rescue
-      Ecto.NoResultsError -> {:error, :not_found, "Post nao existe"}
-    end
+    id
+    |> Blog.get_post()
+    |> post_exists(conn)
   end
+
+  defp post_exists(nil, _conn), do: {:error, :not_found, "Post nao existe"}
+  defp post_exists(post, conn), do: render(conn, "show.json", post_user: get_post_user(post))
 
   def update(conn, %{"id" => id, "post" => post_params}) do
     post = Blog.get_post!(id)

--- a/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
@@ -20,6 +20,11 @@ defmodule ApiBlogsWeb.PostController do
       [ %{post: post, user: user} | get_post_user(posts)]
     end
   end
+  defp get_post_user(post) do
+    with user <- Blog.get_user!(post.user_id) do
+      %{post: post, user: user}
+    end
+  end
 
   def create(conn, %{"post" => post_params}) do
     {:ok, %{"sub" => id}} = UserController.extract_id(conn)
@@ -34,11 +39,10 @@ defmodule ApiBlogsWeb.PostController do
 
   def show(conn, %{"id" => id}) do
     try do
-      post = Blog.get_post!(id)
       post_user =
-        [post]
+        id
+        |> Blog.get_post!()
         |> get_post_user()
-        |> hd()
       render(conn, "show.json", post_user: post_user)
     rescue
       Ecto.NoResultsError -> {:error, :nonexistent_post}

--- a/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
@@ -45,7 +45,7 @@ defmodule ApiBlogsWeb.PostController do
         |> get_post_user()
       render(conn, "show.json", post_user: post_user)
     rescue
-      Ecto.NoResultsError -> {:error, :nonexistent_post}
+      Ecto.NoResultsError -> {:error, :not_found, "Post nao existe"}
     end
   end
 

--- a/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
@@ -33,8 +33,16 @@ defmodule ApiBlogsWeb.PostController do
   end
 
   def show(conn, %{"id" => id}) do
-    post = Blog.get_post!(id)
-    render(conn, "show.json", post: post)
+    try do
+      post = Blog.get_post!(id)
+      post_user =
+        [post]
+        |> get_post_user()
+        |> hd()
+      render(conn, "show.json", post_user: post_user)
+    rescue
+      Ecto.NoResultsError -> {:error, :nonexistent_post}
+    end
   end
 
   def update(conn, %{"id" => id, "post" => post_params}) do

--- a/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
@@ -26,7 +26,7 @@ defmodule ApiBlogsWeb.UserController do
       user = Blog.get_user!(id)
       render(conn, "show.json", user: user)
     rescue
-      Ecto.NoResultsError -> {:error, :nonexistent_user}
+      Ecto.NoResultsError -> {:error, :not_found, "Usuario nao existe"}
     end
   end
 

--- a/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
@@ -22,13 +22,13 @@ defmodule ApiBlogsWeb.UserController do
   end
 
   def show(conn, %{"id" => id}) do
-    try do
-      user = Blog.get_user!(id)
-      render(conn, "show.json", user: user)
-    rescue
-      Ecto.NoResultsError -> {:error, :not_found, "Usuario nao existe"}
-    end
+    id
+    |> Blog.get_user()
+    |> user_exists(conn)
   end
+
+  defp user_exists(nil, _conn), do: {:error, :not_found, "Usuario nao existe"}
+  defp user_exists(user, conn), do: render(conn, "show.json", user: user)
 
   # def update(conn, %{"id" => id, "user" => user_params}) do
   #   user = Blog.get_user!(id)

--- a/api_blogs/lib/api_blogs_web/views/post_view.ex
+++ b/api_blogs/lib/api_blogs_web/views/post_view.ex
@@ -6,8 +6,8 @@ defmodule ApiBlogsWeb.PostView do
     %{data: render_many(posts_users, PostView, "post.json")}
   end
 
-  def render("show.json", %{post: post}) do
-    %{data: render_one(post, PostView, "post.json")}
+  def render("show.json", %{post_user: post_user}) do
+    %{data: render_one(post_user, PostView, "post.json")}
   end
 
   def render("post.json", %{post: %{post: post, user: user}}) do

--- a/api_blogs/test/api_blogs_web/controllers/user_controller_test.exs
+++ b/api_blogs/test/api_blogs_web/controllers/user_controller_test.exs
@@ -137,7 +137,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: "123456"
       }
       conn = post(conn, Routes.user_path(conn, :login), user: invalid_attrs)
-      assert %{"message" => "email and password are required"} = json_response(conn, 400)
+      assert %{"message" => "\"email\" is required"} = json_response(conn, 400)
     end
 
     test "renders errors when no password is provided", %{conn: conn} do
@@ -145,7 +145,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         email: "rubens@email.com"
       }
       conn = post(conn, Routes.user_path(conn, :login), user: invalid_attrs)
-      assert %{"message" => "email and password are required"} = json_response(conn, 400)
+      assert %{"message" => "\"password\" is required"} = json_response(conn, 400)
     end
 
     test "renders errors when email is blank", %{conn: conn} do
@@ -154,7 +154,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: "123456"
       }
       conn = post(conn, Routes.user_path(conn, :login), user: invalid_attrs)
-      assert %{"message" => "email and password are required"} = json_response(conn, 400)
+      assert %{"message" => "\"email\" is not allowed to be empty"} = json_response(conn, 400)
     end
 
     test "renders errors when password is blank", %{conn: conn} do
@@ -163,7 +163,7 @@ defmodule ApiBlogsWeb.UserControllerTest do
         password: ""
       }
       conn = post(conn, Routes.user_path(conn, :login), user: invalid_attrs)
-      assert %{"message" => "email and password are required"} = json_response(conn, 400)
+      assert %{"message" => "\"password\" is not allowed to be empty"} = json_response(conn, 400)
     end
 
     test "renders errors when password is wrong", %{conn: conn} do

--- a/api_blogs/test/api_blogs_web/controllers/user_controller_test.exs
+++ b/api_blogs/test/api_blogs_web/controllers/user_controller_test.exs
@@ -11,62 +11,25 @@ defmodule ApiBlogsWeb.UserControllerTest do
     image: "http://4.bp.blogspot.com/_YA50adQ-7vQ/S1gfR_6ufpI/AAAAAAAAAAk/1ErJGgRWZDg/S45/brett.png",
     password: "123456"
   }
-  # @update_attrs %{
-  #   displayName: "some updated displayName",
-  #   email: "some updated email",
-  #   image: "some updated image",
-  #   password: "some updated password"
-  # }
-  # @invalid_attrs %{displayName: nil, email: nil, image: nil, password: nil}
+  @update_attrs %{
+    displayName: "maria silva",
+    email: "maria@email.com",
+    image: "image.png",
+    password: "654321"
+  }
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
-  describe "list all users" do
-    test "renders two users", %{conn: conn} do
-      new_user = %{
-        displayName: "maria silva",
-        email: "maria@email.com",
-        password: "654321"
-      }
-
-      conn =
-        conn
-        |> post(Routes.user_path(conn, :create), user: @create_attrs)
-        |> post(Routes.user_path(conn, :create), user: new_user)
-
-      conn =
-        build_conn()
-        |> put_valid_jwt_header(get_jwt_from_conn_header(conn))
-        |> get(Routes.user_path(conn, :index))
-
-      assert %{"data" => [ %{"email" => "rubens@email.com"} | [ %{"email" => "maria@email.com"} | _ ]]} = json_response(conn, 200)
-    end
-
-    test "renders errors when jwt is invalid", %{conn: conn} do
-      conn =
-        conn
-        |> put_invalid_jwt_header()
-        |> get(Routes.user_path(conn, :index))
-
-      assert %{"message" => "Token expirado ou invalido"} = json_response(conn, 401)
-    end
-
-    test "renders errors when jwt is missing", %{conn: conn} do
-      conn = get(conn, Routes.user_path(conn, :index))
-      assert %{"message" => "Token nao encontrado"} = json_response(conn, 401)
-    end
-  end
-
   describe "create user" do
     test "renders jwt when data is valid", %{conn: conn} do
       conn = post(conn, Routes.user_path(conn, :create), user: @create_attrs)
-      assert %{"jwt" => _} = json_response(conn, 201)
+      assert %{"jwt" => jwt} = json_response(conn, 201)
 
       conn =
         build_conn()
-        |> put_valid_jwt_header(get_jwt_from_conn_header(conn))
+        |> put_valid_jwt_header(jwt)
         |> get(Routes.user_path(conn, :index))
 
       assert %{"data" => [%{"id" => id}]} = json_response(conn, 200)
@@ -157,100 +120,6 @@ defmodule ApiBlogsWeb.UserControllerTest do
     end
   end
 
-  describe "get user by id" do
-    setup [:add_user_jwt]
-
-    test "renders user info", %{conn: conn, jwt: jwt} do
-      conn =
-        conn
-        |> put_valid_jwt_header(jwt)
-        |> get(Routes.user_path(conn, :index))
-
-      assert %{"data" => [%{"id" => id}]} = json_response(conn, 200)
-
-      conn = get(conn, Routes.user_path(conn, :show, id))
-      assert %{"data" => %{"email" => "rubens@email.com"}} = json_response(conn, 200)
-    end
-
-    test "renders errors when user doesn't exist", %{conn: conn, jwt: jwt} do
-      conn =
-        conn
-        |> put_valid_jwt_header(jwt)
-        |> get(Routes.user_path(conn, :index))
-
-      assert %{"data" => [%{"id" => id}]} = json_response(conn, 200)
-      invalid_id = id + 1
-
-      conn = get(conn, Routes.user_path(conn, :show, invalid_id))
-      assert %{"message" => "Usuario nao existe"} = json_response(conn, 404)
-    end
-
-    test "renders errors when jwt is invalid", %{conn: conn} do
-      conn =
-        conn
-        |> put_invalid_jwt_header()
-        |> get(Routes.user_path(conn, :show, 1))
-
-      assert %{"message" => "Token expirado ou invalido"} = json_response(conn, 401)
-    end
-
-    test "renders errors when jwt is missing", %{conn: conn} do
-      conn = get(conn, Routes.user_path(conn, :show, 1))
-      assert %{"message" => "Token nao encontrado"} = json_response(conn, 401)
-    end
-  end
-
-  # describe "update user" do
-  #   setup [:create_user]
-
-  #   test "renders user when data is valid", %{conn: conn, user: %User{id: id} = user} do
-  #     conn = put(conn, Routes.user_path(conn, :update, user), user: @update_attrs)
-  #     assert %{"id" => ^id} = json_response(conn, 200)["data"]
-
-  #     conn = get(conn, Routes.user_path(conn, :show, id))
-
-  #     assert %{
-  #              "id" => ^id,
-  #              "displayName" => "some updated displayName",
-  #              "email" => "some updated email",
-  #              "image" => "some updated image",
-  #              "password" => "some updated password"
-  #            } = json_response(conn, 200)["data"]
-  #   end
-
-  #   test "renders errors when data is invalid", %{conn: conn, user: user} do
-  #     conn = put(conn, Routes.user_path(conn, :update, user), user: @invalid_attrs)
-  #     assert json_response(conn, 422)["errors"] != %{}
-  #   end
-  # end
-
-  describe "delete user" do
-    setup [:add_user_jwt]
-
-    test "renders deleted user", %{conn: conn, jwt: jwt} do
-      conn =
-        conn
-        |> put_valid_jwt_header(jwt)
-        |> delete(Routes.user_path(conn, :delete))
-
-      assert "" = response(conn, 204)
-    end
-
-    test "renders errors when jwt is invalid", %{conn: conn} do
-      conn =
-        conn
-        |> put_invalid_jwt_header()
-        |> delete(Routes.user_path(conn, :delete))
-
-      assert %{"message" => "Token expirado ou invalido"} = json_response(conn, 401)
-    end
-
-    test "renders errors when jwt is missing", %{conn: conn} do
-      conn = delete(conn, Routes.user_path(conn, :delete))
-      assert %{"message" => "Token nao encontrado"} = json_response(conn, 401)
-    end
-  end
-
   describe "user login" do
     setup [:add_user]
 
@@ -316,6 +185,112 @@ defmodule ApiBlogsWeb.UserControllerTest do
     end
   end
 
+  describe "list all users" do
+    setup [:add_2_users]
+
+    test "renders all users", %{conn: conn} do
+      conn = get(conn, Routes.user_path(conn, :index))
+      assert %{"data" => [ %{"email" => "rubens@email.com"} | [ %{"email" => "maria@email.com"} ]]} = json_response(conn, 200)
+    end
+
+    test "renders errors when jwt is invalid", %{conn: conn} do
+      conn =
+        build_conn()
+        |> put_invalid_jwt_header()
+        |> get(Routes.user_path(conn, :index))
+
+      assert %{"message" => "Token expirado ou invalido"} = json_response(conn, 401)
+    end
+
+    test "renders errors when jwt is missing", %{conn: conn} do
+      conn =
+        build_conn()
+        |> get(Routes.user_path(conn, :index))
+      assert %{"message" => "Token nao encontrado"} = json_response(conn, 401)
+    end
+  end
+
+  describe "get user by id" do
+    setup [:add_user_id]
+
+    test "renders user info", %{conn: conn, id: id} do
+      conn = get(conn, Routes.user_path(conn, :show, id))
+      assert %{"data" => %{"email" => "rubens@email.com"}} = json_response(conn, 200)
+    end
+
+    test "renders errors when user doesn't exist", %{conn: conn, id: id} do
+      invalid_id = id + 1
+
+      conn = get(conn, Routes.user_path(conn, :show, invalid_id))
+      assert %{"message" => "Usuario nao existe"} = json_response(conn, 404)
+    end
+
+    test "renders errors when jwt is invalid", %{conn: conn, id: id} do
+      conn =
+        build_conn()
+        |> put_invalid_jwt_header()
+        |> get(Routes.user_path(conn, :show, id))
+
+      assert %{"message" => "Token expirado ou invalido"} = json_response(conn, 401)
+    end
+
+    test "renders errors when jwt is missing", %{conn: conn, id: id} do
+      conn =
+        build_conn()
+        |> get(Routes.user_path(conn, :show, id))
+      assert %{"message" => "Token nao encontrado"} = json_response(conn, 401)
+    end
+  end
+
+  describe "delete user" do
+    setup [:add_user_jwt]
+
+    test "renders deleted user", %{conn: conn} do
+      conn = delete(conn, Routes.user_path(conn, :delete))
+      assert "" = response(conn, 204)
+    end
+
+    test "renders errors when jwt is invalid", %{conn: conn} do
+      conn =
+        build_conn()
+        |> put_invalid_jwt_header()
+        |> delete(Routes.user_path(conn, :delete))
+
+      assert %{"message" => "Token expirado ou invalido"} = json_response(conn, 401)
+    end
+
+    test "renders errors when jwt is missing", %{conn: conn} do
+      conn =
+        build_conn()
+        |> delete(Routes.user_path(conn, :delete))
+      assert %{"message" => "Token nao encontrado"} = json_response(conn, 401)
+    end
+  end
+
+  # describe "update user" do
+  #   setup [:create_user]
+
+  #   test "renders user when data is valid", %{conn: conn, user: %User{id: id} = user} do
+  #     conn = put(conn, Routes.user_path(conn, :update, user), user: @update_attrs)
+  #     assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+  #     conn = get(conn, Routes.user_path(conn, :show, id))
+
+  #     assert %{
+  #              "id" => ^id,
+  #              "displayName" => "some updated displayName",
+  #              "email" => "some updated email",
+  #              "image" => "some updated image",
+  #              "password" => "some updated password"
+  #            } = json_response(conn, 200)["data"]
+  #   end
+
+  #   test "renders errors when data is invalid", %{conn: conn, user: user} do
+  #     conn = put(conn, Routes.user_path(conn, :update, user), user: @invalid_attrs)
+  #     assert json_response(conn, 422)["errors"] != %{}
+  #   end
+  # end
+
   # defp create_user(_) do
   #   user = user_fixture()
   #   %{user: user}
@@ -326,12 +301,36 @@ defmodule ApiBlogsWeb.UserControllerTest do
   end
 
   defp add_user_jwt %{conn: conn} do
-    conn = post(conn, Routes.user_path(conn, :create), user: @create_attrs)
-    {:ok, conn: build_conn(), jwt: get_jwt_from_conn_header(conn)}
+    {:ok, conn: conn} = add_user(%{conn: conn})
+    jwt = get_jwt_from_conn_response(conn)
+
+    conn =
+      build_conn()
+      |> put_valid_jwt_header(jwt)
+
+    {:ok, conn: conn}
   end
 
-  defp get_jwt_from_conn_header(conn) do
-    [_ | [_ | [_ | [jwt | _]]]] = String.split(conn.resp_body, "\"")
+  defp add_user_id %{conn: conn} do
+    {:ok, conn: conn} = add_user_jwt(%{conn: conn})
+
+    conn = get(conn, Routes.user_path(conn, :index))
+    %{"data" => [%{"id" => id}]} = json_response(conn, 200)
+
+    {:ok, conn: conn, id: id}
+  end
+
+  defp add_2_users %{conn: conn} do
+    {:ok, conn: conn} = add_user_jwt(%{conn: conn})
+    conn =
+      conn
+      |> post(Routes.user_path(conn, :create), user: @update_attrs)
+
+    {:ok, conn: conn}
+  end
+
+  defp get_jwt_from_conn_response(conn) do
+    %{"jwt" => jwt} = json_response(conn, 201)
     jwt
   end
 


### PR DESCRIPTION
[Link da tarefa no Jira](https://trybe.atlassian.net/jira/software/c/projects/LEARN/boards/56?modal=detail&selectedIssue=LEARN-4495&assignee=61eed0dd25edab006afb4305)

A API de blogs deve ter um _endpoint_ capaz de retornar as informações de um _post_ dado seu ID, desde que um token JWT válido esteja presente no _header_ da requisição.

A rota já havia sido criada anteriormente usando a função `resources` no `router`. A função `show` foi modificada para interceptar o erro caso o _post_ buscado não exista, e a função `get_post_user` foi estendida para o caso de buscar um usuário para apenas um _post_. O erro interceptado na função `show` é levado ao `FallbackController`, onde uma mensagem apropriada é exibida. A _view_ `show.json` foi adaptada para renderizar o _post_ juntamente com seu autor. Além disso, foram criados testes para garantir o cumprimento dos requisitos listados no [readme](https://github.com/helenapato/backend-test#8---sua-aplica%C3%A7%C3%A3o-deve-ter-o-endpoint-get-postid) do projeto.

Os testes de `UserController` foram melhorados, dado o aprendizado com os testes de `PostController`.