### PR TITLE
[LEARN-4536] Criando e testando o endpoint PUT /post/:id

### DIFF
--- a/api_blogs/lib/api_blogs/blog.ex
+++ b/api_blogs/lib/api_blogs/blog.ex
@@ -42,18 +42,30 @@ defmodule ApiBlogs.Blog do
   @doc """
   Gets a single user.
 
-  Returns nil if the User does not exist.
+  Returns error if the User does not exist.
 
   ## Examples
 
-      iex> get_user!(123)
+      iex> get_user(123)
       %User{}
 
-      iex> get_user!(456)
-      nil
+      iex> get_user(456)
+      {:error, :not_found, "Usuario nao existe"}
 
   """
-  def get_user(id), do: Repo.get(User, id)
+  def get_user(id) do
+    user = Repo.get(User, id)
+    case user do
+      nil -> {:error, :not_found, "Usuario nao existe"}
+      _ -> {:ok, user}
+    end
+  end
+
+  def get_user_from_conn(conn) do
+    with {:ok, %{"sub" => id}} <- extract_id(conn) do
+      get_user(id)
+    end
+  end
 
   @doc """
   Creates a user.
@@ -120,7 +132,7 @@ defmodule ApiBlogs.Blog do
     User.changeset(user, attrs)
   end
 
-  def extract_id(%{private: %{guardian_default_token: token}}) do
+  defp extract_id(%{private: %{guardian_default_token: token}}) do
     Guardian.decode_and_verify(token)
   end
 
@@ -180,10 +192,10 @@ defmodule ApiBlogs.Blog do
 
   ## Examples
 
-      iex> get_post!(123)
+      iex> get_post(123)
       %Post{}
 
-      iex> get_post!(456)
+      iex> get_post(456)
       {:error, :not_found, "Post nao existe"}
 
   """

--- a/api_blogs/lib/api_blogs/blog.ex
+++ b/api_blogs/lib/api_blogs/blog.ex
@@ -120,9 +120,8 @@ defmodule ApiBlogs.Blog do
     User.changeset(user, attrs)
   end
 
-  def extract_id(conn) do
-    conn.private[:guardian_default_token]
-    |> Guardian.decode_and_verify()
+  def extract_id(%{private: %{guardian_default_token: token}}) do
+    Guardian.decode_and_verify(token)
   end
 
   alias ApiBlogs.Blog.Post

--- a/api_blogs/lib/api_blogs/blog.ex
+++ b/api_blogs/lib/api_blogs/blog.ex
@@ -62,7 +62,7 @@ defmodule ApiBlogs.Blog do
   end
 
   def get_user_from_conn(conn) do
-    with {:ok, %{"sub" => id}} <- extract_id(conn) do
+    with {:ok, id} <- extract_id(conn) do
       get_user(id)
     end
   end
@@ -133,7 +133,8 @@ defmodule ApiBlogs.Blog do
   end
 
   defp extract_id(%{private: %{guardian_default_token: token}}) do
-    Guardian.decode_and_verify(token)
+    {:ok, %{"sub" => id}} = Guardian.decode_and_verify(token)
+    {:ok, id}
   end
 
   alias ApiBlogs.Blog.Post
@@ -226,7 +227,7 @@ defmodule ApiBlogs.Blog do
   end
 
   def add_params_create_post(conn, post_params) do
-    {:ok, %{"sub" => id}} = extract_id(conn)
+    {:ok, id} = extract_id(conn)
     new_post = Map.put(post_params, "user_id", id)
     {:ok, new_post}
   end
@@ -252,7 +253,7 @@ defmodule ApiBlogs.Blog do
   def update_post(%Post{} = _post, %{"title" => _} = attrs), do: {:error, :bad_request, "\"content\" is required"}
 
   def check_valid_update(conn, post, post_params) do
-    with {:ok, %{"sub" => user_id}} <- extract_id(conn),
+    with {:ok, user_id} <- extract_id(conn),
          int_user_id <- convert_string_to_int(user_id),
          {:ok, %Post{} = post} <- check_valid_user(int_user_id, post) do
       {:ok, post}

--- a/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
@@ -22,13 +22,10 @@ defmodule ApiBlogsWeb.UserController do
   end
 
   def show(conn, %{"id" => id}) do
-    id
-    |> Blog.get_user()
-    |> user_exists(conn)
+    with {:ok, %User{} = user} <- Blog.get_user(id) do
+      render(conn, "show.json", user: user)
+    end
   end
-
-  defp user_exists(nil, _conn), do: {:error, :not_found, "Usuario nao existe"}
-  defp user_exists(user, conn), do: render(conn, "show.json", user: user)
 
   # def update(conn, %{"id" => id, "user" => user_params}) do
   #   user = Blog.get_user!(id)
@@ -39,11 +36,10 @@ defmodule ApiBlogsWeb.UserController do
   # end
 
   def delete(conn, _params) do
-    with {:ok, %{"sub" => id}} <- Blog.extract_id(conn),
-      user <- Blog.get_user!(id),
-      {:ok, %User{}} <- Blog.delete_user(user) do
-        send_resp(conn, :no_content, "")
-      end
+    with {:ok, %User{} = user} <- Blog.get_user_from_conn(conn),
+         {:ok, %User{}} <- Blog.delete_user(user) do
+      send_resp(conn, :no_content, "")
+    end
   end
 
   def login(conn, %{"user" => user_params}) do

--- a/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/user_controller.ex
@@ -39,16 +39,11 @@ defmodule ApiBlogsWeb.UserController do
   # end
 
   def delete(conn, _params) do
-    with {:ok, %{"sub" => id}} <- extract_id(conn),
+    with {:ok, %{"sub" => id}} <- Blog.extract_id(conn),
       user <- Blog.get_user!(id),
       {:ok, %User{}} <- Blog.delete_user(user) do
         send_resp(conn, :no_content, "")
       end
-  end
-
-  def extract_id(conn) do
-    conn.private[:guardian_default_token]
-    |> Guardian.decode_and_verify()
   end
 
   def login(conn, %{"user" => user_params}) do


### PR DESCRIPTION
[Link da tarefa no Jira](https://trybe.atlassian.net/jira/software/c/projects/LEARN/boards/56?modal=detail&selectedIssue=LEARN-4536&assignee=61eed0dd25edab006afb4305)

A API de blogs deve ter um _endpoint_ capaz de atualizar as informações de um post dado seu ID, desde que o token JWT de seu autor esteja presente no header da requisição.

A rota já havia sido criada anteriormente usando a função `resources` no `router`. A função `update` foi modificada para buscar o post, verificar se os parâmetros fornecidos são válidos e então fazer as mudanças necessárias e renderizar a mesma _view_ de `create.json`. Foram criados testes para garantir o cumprimento dos requisitos listados no [readme](https://github.com/helenapato/backend-test#9---sua-aplica%C3%A7%C3%A3o-deve-ter-o-endpoint-put-postid) do projeto.

Seguindo orientações do time, foi feita uma refatoração no `post_controller`, para tirar a lógica do sistema do _controller_ e levá-la para o contexto. Isso também será feito com o `user_controller`.