### PR TITLE
[LEARN-4612] Criar endpoint DELETE /post/:id

### DIFF
--- a/api_blogs/lib/api_blogs/blog.ex
+++ b/api_blogs/lib/api_blogs/blog.ex
@@ -252,10 +252,10 @@ defmodule ApiBlogs.Blog do
   def update_post(%Post{} = _post, %{"content" => _} = attrs), do: {:error, :bad_request, "\"title\" is required"}
   def update_post(%Post{} = _post, %{"title" => _} = attrs), do: {:error, :bad_request, "\"content\" is required"}
 
-  def check_valid_update(conn, post, post_params) do
+  def check_valid_user(conn, post) do
     with {:ok, user_id} <- extract_id(conn),
          int_user_id <- convert_string_to_int(user_id),
-         {:ok, %Post{} = post} <- check_valid_user(int_user_id, post) do
+         {:ok, %Post{} = post} <- is_user_author(int_user_id, post) do
       {:ok, post}
     end
   end
@@ -266,8 +266,8 @@ defmodule ApiBlogs.Blog do
     |> elem(0)
   end
 
-  defp check_valid_user(id, post) when id != post.user_id, do: {:error, :unauthorized, "Usuario nao autorizado"}
-  defp check_valid_user(_id, post), do: {:ok, post}
+  defp is_user_author(id, post) when id != post.user_id, do: {:error, :unauthorized, "Usuario nao autorizado"}
+  defp is_user_author(_id, post), do: {:ok, post}
 
   @doc """
   Deletes a post.

--- a/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
@@ -30,16 +30,16 @@ defmodule ApiBlogsWeb.PostController do
 
   def update(conn, %{"id" => id, "post" => post_params}) do
     with {:ok, %Post{} = post} <- Blog.get_post(id),
-         {:ok, %Post{} = post} <- Blog.check_valid_update(conn, post, post_params),
+         {:ok, %Post{} = post} <- Blog.check_valid_user(conn, post),
          {:ok, %Post{} = post} <- Blog.update_post(post, post_params) do
       render(conn, "create.json", post: post)
     end
   end
 
   def delete(conn, %{"id" => id}) do
-    post = Blog.get_post!(id)
-
-    with {:ok, %Post{}} <- Blog.delete_post(post) do
+    with {:ok, %Post{} = post} <- Blog.get_post(id),
+         {:ok, %Post{} = post} <- Blog.check_valid_user(conn, post),
+         {:ok, %Post{}} <- Blog.delete_post(post) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/api_blogs/test/api_blogs_web/controllers/post_controller_test.exs
+++ b/api_blogs/test/api_blogs_web/controllers/post_controller_test.exs
@@ -163,10 +163,10 @@ defmodule ApiBlogsWeb.PostControllerTest do
   describe "update post" do
     setup [:add_post_2_users]
 
-    test "renders post when data is valid", %{conn: conn, post: %{"id" => id} = post} do
+    test "renders post when data is valid", %{conn: conn, post: %{"id" => id}} do
       conn =
         conn
-        |> put(Routes.post_path(conn, :update, id, post), post: @update_attrs)
+        |> put(Routes.post_path(conn, :update, id), post: @update_attrs)
         |> get(Routes.post_path(conn, :show, id))
 
       assert %{
@@ -178,49 +178,49 @@ defmodule ApiBlogsWeb.PostControllerTest do
       } = json_response(conn, 200)
     end
 
-    test "renders errors when post doesn't exist", %{conn: conn, post: %{"id" => id} = post} do
+    test "renders errors when post doesn't exist", %{conn: conn, post: %{"id" => id}} do
       invalid_id = id + 1
-      conn = put(conn, Routes.post_path(conn, :update, invalid_id, post), post: @update_attrs)
+      conn = put(conn, Routes.post_path(conn, :update, invalid_id), post: @update_attrs)
       assert %{"message" => "Post nao existe"} = json_response(conn, 404)
     end
 
-    test "renders errors when user is unauthorized", %{conn: conn, post: %{"id" => id} = post, jwt: jwt} do
+    test "renders errors when user is unauthorized", %{conn: conn, post: %{"id" => id}, jwt: jwt} do
       conn =
         build_conn()
         |> put_valid_jwt_header(jwt)
-        |> put(Routes.post_path(conn, :update, id, post), post: @update_attrs)
+        |> put(Routes.post_path(conn, :update, id), post: @update_attrs)
       assert %{"message" => "Usuario nao autorizado"} = json_response(conn, 401)
     end
 
-    test "renders errors when no title is provided", %{conn: conn, post: %{"id" => id} = post} do
+    test "renders errors when no title is provided", %{conn: conn, post: %{"id" => id}} do
       invalid_attrs = %{
         content: "blablabla"
       }
-      conn = put(conn, Routes.post_path(conn, :update, id, post), post: invalid_attrs)
+      conn = put(conn, Routes.post_path(conn, :update, id), post: invalid_attrs)
       assert %{"message" => "\"title\" is required"} = json_response(conn, 400)
     end
 
-    test "renders errors when no content is provided", %{conn: conn, post: %{"id" => id} = post} do
+    test "renders errors when no content is provided", %{conn: conn, post: %{"id" => id}} do
       invalid_attrs = %{
         title: "title"
       }
-      conn = put(conn, Routes.post_path(conn, :update, id, post), post: invalid_attrs)
+      conn = put(conn, Routes.post_path(conn, :update, id), post: invalid_attrs)
       assert %{"message" => "\"content\" is required"} = json_response(conn, 400)
     end
 
-    test "renders errors when jwt is invalid", %{conn: conn, post: %{"id" => id} = post} do
+    test "renders errors when jwt is invalid", %{conn: conn, post: %{"id" => id}} do
       conn =
         build_conn()
         |> put_invalid_jwt_header()
-        |> put(Routes.post_path(conn, :update, id, post), post: @update_attrs)
+        |> put(Routes.post_path(conn, :update, id), post: @update_attrs)
 
       assert %{"message" => "Token expirado ou invalido"} = json_response(conn, 401)
     end
 
-    test "renders errors when jwt is missing", %{conn: conn, post: %{"id" => id} = post} do
+    test "renders errors when jwt is missing", %{conn: conn, post: %{"id" => id}} do
       conn =
         build_conn()
-        |> put(Routes.post_path(conn, :update, id, post), post: @update_attrs)
+        |> put(Routes.post_path(conn, :update, id), post: @update_attrs)
       assert %{"message" => "Token nao encontrado"} = json_response(conn, 401)
     end
   end


### PR DESCRIPTION
[Link da tarefa no Jira](https://trybe.atlassian.net/jira/software/c/projects/LEARN/boards/56?modal=detail&selectedIssue=LEARN-4612&assignee=61eed0dd25edab006afb4305)

A API de blogs deve ter um endpoint capaz de deletar um post dado seu ID, desde que o token JWT de seu autor esteja presente no header da requisição.

A rota já havia sido criada anteriormente usando a função `resources` no router. A função `delete` foi modificada para buscar o post, verificar se o usuário atual é o autor do post e então deletar o post, retornando uma visualização vazia. Foram criados testes para garantir o cumprimento dos requisitos listados no [readme](https://github.com/helenapato/backend-test#11---sua-aplica%C3%A7%C3%A3o-deve-ter-o-endpoint-delete-postid) do projeto.
