### PR TITLE
[LEARN-4647] Criando e testando o endpoint GET post/search?q=:searchTerm

### DIFF
--- a/api_blogs/lib/api_blogs/blog.ex
+++ b/api_blogs/lib/api_blogs/blog.ex
@@ -315,12 +315,11 @@ defmodule ApiBlogs.Blog do
   end
 
   def search_posts_by_term(searchTerm) do
-    query =
-      from p in Post,
-      where: ilike(p.title, ^"%#{searchTerm}%")
-        or ilike(p.content, ^"%#{searchTerm}%")
-    result = Repo.all(query)
-    case result do
+    from p in Post,
+     where: ilike(p.title, ^"%#{searchTerm}%")
+       or ilike(p.content, ^"%#{searchTerm}%")
+    |> Repo.all()
+    |> case  do
       [] -> []
       _ -> get_post_user(result)
     end

--- a/api_blogs/lib/api_blogs/blog.ex
+++ b/api_blogs/lib/api_blogs/blog.ex
@@ -61,6 +61,10 @@ defmodule ApiBlogs.Blog do
     end
   end
 
+  @doc """
+  Returns the user whose jwt token is in the conn header.
+
+  """
   def get_user_from_conn(conn) do
     with {:ok, id} <- extract_id(conn) do
       get_user(id)
@@ -132,13 +136,21 @@ defmodule ApiBlogs.Blog do
     User.changeset(user, attrs)
   end
 
+  @doc """
+  Returns the id of the user whose jwt token is in the conn header.
+
+  """
   defp extract_id(%{private: %{guardian_default_token: token}}) do
     {:ok, %{"sub" => id}} = Guardian.decode_and_verify(token)
     {:ok, id}
   end
 
   @doc """
-  User login.
+  Checks if email and password were provided for login and if they are correct.
+  If they are, returns a tuple of {:ok, user}.
+
+  Returns error if anything is wrong.
+
   """
   def do_login(%{"email" => "", "password" => _password}), do: {:error, :bad_request, "\"email\" is not allowed to be empty"}
   def do_login(%{"email" => _email, "password" => ""}), do: {:error, :bad_request, "\"password\" is not allowed to be empty"}
@@ -169,6 +181,13 @@ defmodule ApiBlogs.Blog do
     Repo.all(Post)
   end
 
+  @doc """
+  Using a list of posts, creates a list of maps of the posts and it's author users.
+
+
+  With a single post, creates a single map of the post and it's author.
+
+  """
   def get_post_user([]), do: []
   def get_post_user([post | posts]) do
     with user <- get_user!(post.user_id) do
@@ -181,6 +200,10 @@ defmodule ApiBlogs.Blog do
     end
   end
 
+  @doc """
+  Returns a list of all posts in database together with their authors.
+
+  """
   def list_posts_with_users() do
     list_posts()
     |> get_post_user()
@@ -242,6 +265,10 @@ defmodule ApiBlogs.Blog do
     |> Repo.insert()
   end
 
+  @doc """
+  Creates a map with the required parameters to create a post.
+
+  """
   def add_params_create_post(conn, post_params) do
     {:ok, id} = extract_id(conn)
     new_post = Map.put(post_params, "user_id", id)
@@ -249,7 +276,7 @@ defmodule ApiBlogs.Blog do
   end
 
   @doc """
-  Updates a post.
+  Updates a post, if the update is valid.
 
   ## Examples
 
@@ -268,6 +295,11 @@ defmodule ApiBlogs.Blog do
   def update_post(%Post{} = _post, %{"content" => _} = _attrs), do: {:error, :bad_request, "\"title\" is required"}
   def update_post(%Post{} = _post, %{"title" => _} = _attrs), do: {:error, :bad_request, "\"content\" is required"}
 
+
+  @doc """
+  Checks if the user whose jwt token is in the conn header is allowed to edit a post.
+
+  """
   def check_valid_user(conn, post) do
     with {:ok, user_id} <- extract_id(conn),
          int_user_id <- convert_string_to_int(user_id),
@@ -276,12 +308,20 @@ defmodule ApiBlogs.Blog do
     end
   end
 
+  @doc """
+  Converts a string number to int.
+
+  """
   defp convert_string_to_int(string) do
     string
     |> Integer.parse()
     |> elem(0)
   end
 
+  @doc """
+  Checks if the id given is that of the post's author. In case it's not, returns error.
+
+  """
   defp is_user_author(id, post) when id != post.user_id, do: {:error, :unauthorized, "Usuario nao autorizado"}
   defp is_user_author(_id, post), do: {:ok, post}
 
@@ -314,12 +354,18 @@ defmodule ApiBlogs.Blog do
     Post.changeset(post, attrs)
   end
 
+  @doc """
+  Searches the database for posts with a given term in title or content.
+  Returns a list of posts with users wich match the term.
+
+  """
   def search_posts_by_term(searchTerm) do
-    from p in Post,
-     where: ilike(p.title, ^"%#{searchTerm}%")
-       or ilike(p.content, ^"%#{searchTerm}%")
-    |> Repo.all()
-    |> case  do
+    query =
+      from p in Post,
+      where: ilike(p.title, ^"%#{searchTerm}%")
+        or ilike(p.content, ^"%#{searchTerm}%")
+    result = Repo.all(query)
+    case result do
       [] -> []
       _ -> get_post_user(result)
     end

--- a/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
+++ b/api_blogs/lib/api_blogs_web/controllers/post_controller.ex
@@ -21,6 +21,10 @@ defmodule ApiBlogsWeb.PostController do
     end
   end
 
+  def show(conn, %{"id" => "search", "q" => searchTerm}) do
+    posts_with_term = Blog.search_posts_by_term(searchTerm)
+    render(conn, "index.json", posts_users: posts_with_term)
+  end
   def show(conn, %{"id" => id}) do
     with {:ok, %Post{} = post} <- Blog.get_post(id),
          post_user <- Blog.get_post_user(post) do

--- a/api_blogs/test/api_blogs_web/controllers/post_controller_test.exs
+++ b/api_blogs/test/api_blogs_web/controllers/post_controller_test.exs
@@ -264,6 +264,97 @@ defmodule ApiBlogsWeb.PostControllerTest do
     end
   end
 
+  describe "search posts by term" do
+    setup [:add_2_posts]
+
+    test "renders posts when term is in title", %{conn: conn} do
+      conn = get(conn, Routes.post_path(conn, :show, "search", q: "august"))
+
+      assert %{
+        "data" => [
+          %{
+            "content" => "The whole text for the blog post goes here in this key",
+            "title" => "Latest updates, August 1st",
+            "user" => %{
+              "displayName" => "rubens silva",
+              "email" => "rubens@email.com",
+              "image" => "http://4.bp.blogspot.com/_YA50adQ-7vQ/S1gfR_6ufpI/AAAAAAAAAAk/1ErJGgRWZDg/S45/brett.png"
+            }
+          }
+        ]
+      } = json_response(conn, 200)
+    end
+
+    test "renders posts when term is in content", %{conn: conn} do
+      conn = get(conn, Routes.post_path(conn, :show, "search", q: "bla"))
+
+      assert %{
+        "data" => [
+          %{
+            "content" => "blablabla",
+            "title" => "titulo",
+            "user" => %{
+              "displayName" => "rubens silva",
+              "email" => "rubens@email.com",
+              "image" => "http://4.bp.blogspot.com/_YA50adQ-7vQ/S1gfR_6ufpI/AAAAAAAAAAk/1ErJGgRWZDg/S45/brett.png"
+            }
+          }
+        ]
+      } = json_response(conn, 200)
+    end
+
+    test "renders all posts when term is blank", %{conn: conn} do
+      conn = get(conn, Routes.post_path(conn, :show, "search", q: ""))
+
+      assert %{
+        "data" => [
+          %{
+            "content" => "The whole text for the blog post goes here in this key",
+            "title" => "Latest updates, August 1st",
+            "user" => %{
+              "displayName" => "rubens silva",
+              "email" => "rubens@email.com",
+              "image" => "http://4.bp.blogspot.com/_YA50adQ-7vQ/S1gfR_6ufpI/AAAAAAAAAAk/1ErJGgRWZDg/S45/brett.png"
+            }
+          },
+          %{
+            "content" => "blablabla",
+            "title" => "titulo",
+            "user" => %{
+              "displayName" => "rubens silva",
+              "email" => "rubens@email.com",
+              "image" => "http://4.bp.blogspot.com/_YA50adQ-7vQ/S1gfR_6ufpI/AAAAAAAAAAk/1ErJGgRWZDg/S45/brett.png"
+            }
+          }
+        ]
+      } = json_response(conn, 200)
+    end
+
+    test "renders empty list when term is not found", %{conn: conn} do
+      conn = get(conn, Routes.post_path(conn, :show, "search", q: "casa"))
+
+      assert %{
+        "data" => []
+      } = json_response(conn, 200)
+    end
+
+    test "renders errors when jwt is invalid", %{conn: conn} do
+      conn =
+        build_conn()
+        |> put_invalid_jwt_header()
+        |> get(Routes.post_path(conn, :show, "search", q: "august"))
+
+      assert %{"message" => "Token expirado ou invalido"} = json_response(conn, 401)
+    end
+
+    test "renders errors when jwt is missing", %{conn: conn} do
+      conn =
+        build_conn()
+        |> get(Routes.post_path(conn, :show, "search", q: "august"))
+      assert %{"message" => "Token nao encontrado"} = json_response(conn, 401)
+    end
+  end
+
   defp add_user_jwt %{conn: conn} do
     jwt =
       conn


### PR DESCRIPTION
[Link da tarefa no Jira](https://trybe.atlassian.net/jira/software/c/projects/LEARN/boards/56?modal=detail&selectedIssue=LEARN-4647&assignee=61eed0dd25edab006afb4305)

A API de blogs deve ter um endpoint capaz de pesquisar por um termo no título ou conteúdo de todos os posts, desde que um token JWT válido esteja presente no header da requisição.

A rota da função `show` foi reutilizada, com um novo pattern match em `search` como ID. Depois, uma função que faz a query no banco de dados é chamada para obter os posts. Foram criados testes para garantir o cumprimento dos requisitos listados no [readme](https://github.com/helenapato/backend-test#10----sua-aplica%C3%A7%C3%A3o-deve-ter-o-endpoint-get-postsearchqsearchterm) do projeto.